### PR TITLE
gitconfig: Enable useConfigOnly

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,7 +1,6 @@
 [user]
-	name = Masayuki Igawa
-	email = masayuki@igawa.io
 	username = masayukig
+	useConfigOnly = true
 [color]
 	ui = auto
 [core]


### PR DESCRIPTION
This commit enables useConfigOnly option in the global .gitconfig. I'd
like to switch my account between the internal work and upstream work.
This option enable it.